### PR TITLE
bump to `dfx-0.7.0`

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -23,7 +23,7 @@
       "packtool": ""
     }
   },
-  "dfx": "0.6.14",
+  "dfx": "0.7.0",
   "networks": {
     "ic": {
       "providers": [


### PR DESCRIPTION
You can install it using `env DFX_VERSION=0.7.0 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"`.

May I also suggest to create a branch (`bare-bones-vue`, based 47bd2b6 + this PR cherry-picked) and advertise that on the README?